### PR TITLE
Added ability to print the output of 'docker build' command

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -104,6 +104,10 @@ pub struct BuildAndPushCommandArguments {
   #[clap(long, env, default_value = "false")]
   pub cache: bool,
 
+  /// Print stdout of the shell commands
+  #[clap(long, env, default_value = "false")]
+  pub need_stdout: bool,
+
   /// Pass --build-arg to the build command
   #[clap(long, env)]
   pub build_arg: Option<Vec<String>>,


### PR DESCRIPTION
I' ve added a new boolean flag for the `build-and-push` command named `--need-stdout` which enables logging of the image build process.

![image](https://github.com/user-attachments/assets/7fc6f060-1a9a-4063-af07-e1cd2bf7c690)
