### PR TITLE
Added ability to specify target image platform.

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -120,6 +120,10 @@ pub struct BuildAndPushCommandArguments {
   /// Set the build target for the docker image
   #[clap(long, env)]
   pub target: Option<String>,
+
+  /// Set platform for docker image
+  #[clap(long, env, default_value = "linux/amd64")]
+  pub platform: String,
 }
 
 #[derive(Subcommand, Debug)]

--- a/src/commands/build_and_push.rs
+++ b/src/commands/build_and_push.rs
@@ -6,6 +6,8 @@ use futures::try_join;
 use std::process::Stdio;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command as TokioCommand;
+use std::process::Stdio;
+use tokio::io::{BufReader, AsyncBufReadExt};
 
 pub struct BuildAndPushCommand {
   config: Config,

--- a/src/commands/build_and_push.rs
+++ b/src/commands/build_and_push.rs
@@ -6,9 +6,6 @@ use futures::try_join;
 use std::process::Stdio;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command as TokioCommand;
-use std::process::Stdio;
-use tokio::io::{AsyncBufReadExt, BufReader};
-use tokio::process::Command as TokioCommand;
 
 pub struct BuildAndPushCommand {
   config: Config,
@@ -21,6 +18,7 @@ pub struct BuildAndPushCommand {
   repository: Option<String>,
   target: Option<String>,
   need_stdout: bool,
+  platform: String,
 }
 
 impl BuildAndPushCommand {
@@ -38,6 +36,7 @@ impl BuildAndPushCommand {
       repository: args.repository,
       target: args.target,
       need_stdout: args.need_stdout,
+      platform: args.platform,
     }
   }
 
@@ -127,7 +126,7 @@ impl BuildAndPushCommand {
     let mut command = TokioCommand::new("docker");
     command.arg("build");
     command.arg(self.directory.clone());
-
+    command.arg(self.platform.clone());
     command.arg(format!("--file={}", self.file.clone()));
 
     if let Some(build_arg) = &self.build_arg {

--- a/src/commands/build_and_push.rs
+++ b/src/commands/build_and_push.rs
@@ -7,7 +7,8 @@ use std::process::Stdio;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command as TokioCommand;
 use std::process::Stdio;
-use tokio::io::{BufReader, AsyncBufReadExt};
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Command as TokioCommand;
 
 pub struct BuildAndPushCommand {
   config: Config,


### PR DESCRIPTION
This is can be useful for those who use `ecs_helpers` locally on non-x86 platforms like Apple Silicon.