### PR TITLE
Fixed 'build_and_push' command

### DIFF
--- a/src/commands/build_and_push.rs
+++ b/src/commands/build_and_push.rs
@@ -126,7 +126,7 @@ impl BuildAndPushCommand {
     let mut command = TokioCommand::new("docker");
     command.arg("build");
     command.arg(self.directory.clone());
-    command.arg(self.platform.clone());
+    command.arg(format!("--platform={}", self.platform.clone()));
     command.arg(format!("--file={}", self.file.clone()));
 
     if let Some(build_arg) = &self.build_arg {


### PR DESCRIPTION
Due to missed `--platform` flag prefix there is an error like the following one

![image](https://github.com/user-attachments/assets/bd7cc481-57fb-454e-b918-f0785978f877)
